### PR TITLE
fix(cli): install script windows compatibility

### DIFF
--- a/components/cli/docs/install.bash
+++ b/components/cli/docs/install.bash
@@ -16,7 +16,10 @@ else
   exit 1
 fi
 
-FILE="bun-${OS}-${ARCH}"
+case "$OS" in
+  windows|mingw*|msys*|cygwin*) FILE="bun-windows-${ARCH}.exe" ;;
+  *) FILE="bun-${OS}-${ARCH}" ;;
+esac
 
 LATEST_RELEASE=$(curl -s "https://api.github.com/repos/crystallizeapi/cli/releases/latest" | grep tag_name | cut -d'"' -f 4)
 URL="https://github.com/CrystallizeAPI/cli/releases/download/${LATEST_RELEASE}/crystallize-${FILE}"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Fixed tickets | #... 

When attempting to install the new CLI on Windows (via `curl -LSs https://crystallizeapi.github.io/cli/install.bash | bash`) on anything other than Command Prompt, it fails to download the file.

As far as I can tell, it is because `OS=$(uname -s | tr '[:upper:]' '[:lower:]')` isn't returning `windows`, but variants. In my case, running GitBash and Powershell it returns `mingw**`. In these environments, it also seems that the extension `.exe` is required.

I thought it would be convenient to provide a fix for this, which I now humbly submit to the Crystallize Council for review.
